### PR TITLE
Ability to add users to groups when they are authenticated with google auth 

### DIFF
--- a/Auth/GoogleAuthProvider.php
+++ b/Auth/GoogleAuthProvider.php
@@ -59,8 +59,9 @@ class GoogleAuthProvider extends Base implements OAuthAuthenticationProviderInte
     {
         $profile = $this->getProfile();
 
-        if (! empty($profile)) {
+        if (!empty($profile)) {
             $this->userInfo = new GoogleUserProvider($profile, $this->isAccountCreationAllowed($profile));
+
             return true;
         }
 
@@ -179,7 +180,7 @@ class GoogleAuthProvider extends Base implements OAuthAuthenticationProviderInte
      *
      * @access public
      * @return string
-    */
+     */
     public function getGoogleEmailDomains()
     {
         if (defined('GOOGLE_EMAIL_DOMAINS') && GOOGLE_EMAIL_DOMAINS) {
@@ -187,6 +188,21 @@ class GoogleAuthProvider extends Base implements OAuthAuthenticationProviderInte
         }
 
         return $this->configModel->get('google_email_domains');
+    }
+
+    /**
+     * Get Google allowed email domains
+     *
+     * @access public
+     * @return string
+     */
+    public function getGoogleSignupGroups()
+    {
+        if (defined('GOOGLE_SIGNUP_GROUPS') && GOOGLE_SIGNUP_GROUPS) {
+            return GOOGLE_SIGNUP_GROUPS;
+        }
+
+        return $this->configModel->get('google_signup_groups');
     }
 
     /**
@@ -201,7 +217,7 @@ class GoogleAuthProvider extends Base implements OAuthAuthenticationProviderInte
         if ($this->configModel->get('google_account_creation', 0) == 1) {
             $domains = $this->getGoogleEmailDomains();
 
-            if (! empty($domains)) {
+            if (!empty($domains)) {
                 return $this->validateDomainRestriction($profile, $domains);
             }
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -38,6 +38,7 @@ class Plugin extends Base
     public function onLoginSuccess(AuthSuccessEvent $event)
     {
         if ($event->getAuthType() === 'Google') {
+            /** @var GoogleAuthProvider */
             $provider = $this->authenticationManager->getProvider($event->getAuthType());
             $avatar_url = $provider->getUser()->getAvatarUrl();
             $user_id = $this->userSession->getId();
@@ -50,6 +51,18 @@ class Plugin extends Base
                 }
 
                 $this->userMetadataModel->save($user_id, $options);
+            }
+
+            $signup_groups = $provider->getGoogleSignupGroups();
+            $user_groups = array_column($this->groupMemberModel->getGroups($user_id), 'id', 'id');
+            if (!empty($signup_groups) && !is_null($signup_groups)) {
+                $signup_groups = explode(',', $signup_groups);
+                $groups = $this->groupModel->getQuery()->in('name', $signup_groups)->findAll();
+                foreach ($groups as $signup_group) {
+                    if (!isset($user_groups[$signup_group['id']])) {
+                        $this->groupMemberModel->addUser($signup_group['id'], $user_id);
+                    }
+                }
             }
         }
     }

--- a/Template/config/integration.php
+++ b/Template/config/integration.php
@@ -16,6 +16,11 @@
     <?= $this->form->text('google_email_domains', $values) ?>
     <p class="form-help"><?= t('Use a comma to enter multiple domains: domain1.tld, domain2.tld') ?></p>
 
+    <?= $this->form->label(t('Add new users to groups'), 'google_signup_groups') ?>
+    <?= $this->form->text('google_signup_groups', $values) ?>
+    <p class="form-help"><?= t('Use a comma to enter multiple group names: developers,designers') ?></p>
+
+
     <p class="form-help"><a href="https://github.com/kanboard/plugin-google-auth#documentation"><?= t('Help on Google authentication') ?></a></p>
 
     <div class="form-actions">

--- a/User/GoogleUserProvider.php
+++ b/User/GoogleUserProvider.php
@@ -18,16 +18,23 @@ class GoogleUserProvider extends OAuthUserProvider
     protected $allowUserCreation;
 
     /**
+     * @var array
+     */
+    protected $externalGroupIds;
+
+    /**
      * Constructor
      *
      * @access public
      * @param  array $user
      * @param  bool   $allowUserCreation
+     * @param  array   $externalGroupIds
      */
-    public function __construct(array $user, $allowUserCreation = false)
+    public function __construct(array $user, $allowUserCreation = false, $externalGroupIds = [])
     {
         $this->user = $user;
         $this->allowUserCreation = $allowUserCreation;
+        $this->externalGroupIds = $externalGroupIds;
     }
 
     /**
@@ -95,5 +102,16 @@ class GoogleUserProvider extends OAuthUserProvider
         }
 
         return array();
+    }
+
+    /**
+     * Get external group ids
+     *
+     * @access public
+     * @return array
+     */
+    public function getExternalGroupIds()
+    {
+        return $this->externalGroupIds;
     }
 }


### PR DESCRIPTION
what it does?
- add a list of comma separated group names in Google Auth Integration and anyone using google will be added to that group 
what is changed?
- a textbox in integration settings for group names to be added
- some changes to Plugin.php and other files so it can check for users groups on success authentication and update group membership based on settings...  